### PR TITLE
Add GPLv2.txt to license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md LICENSE
+include README.md LICENSE GPLv2.txt


### PR DESCRIPTION
This is in support of #5 as conda-forge requires all licenses to be included.